### PR TITLE
add ability to differentiate requests by body

### DIFF
--- a/src/main/kotlin/io/kotest/extensions/httpstub/dsl.kt
+++ b/src/main/kotlin/io/kotest/extensions/httpstub/dsl.kt
@@ -3,6 +3,8 @@ package io.kotest.extensions.httpstub
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.binaryEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.matching.EqualToPattern
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -16,9 +18,13 @@ fun mappings(configure: HttpStubber.() -> Unit): HttpStubber.() -> Unit {
 class RequestStubber {
 
    val headers = mutableMapOf<String, String>()
+   var requestBody: String? = null
 
    fun header(name: String, value: String) {
       headers[name] = value
+   }
+   fun body(json: String) {
+      requestBody = json
    }
 }
 
@@ -28,6 +34,9 @@ class HttpStubber(private val server: WireMockServer) {
       val rs = RequestStubber()
       val resp = rs.fn()
       rs.headers.forEach { (name, value) -> builder.withHeader(name, EqualToPattern(value)) }
+      if (rs.requestBody != null) {
+         builder.withRequestBody(equalToJson(rs.requestBody))
+      }
       server.stubFor(builder.willReturn(resp.toReturnBuilder()))
    }
 

--- a/src/test/kotlin/io/kotest/extensions/httpstub/RequestBodyTest.kt
+++ b/src/test/kotlin/io/kotest/extensions/httpstub/RequestBodyTest.kt
@@ -1,0 +1,45 @@
+package io.kotest.extensions.httpstub
+
+import io.kotest.core.extensions.install
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.apache.Apache
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+
+class RequestBodyTest : FunSpec() {
+   init {
+
+      val client = HttpClient(Apache)
+      val server = install(HttpStub)
+
+      test("differentiate requests with request body") {
+         server.mappings {
+            post("/foo") {
+               body("""{"test": true}""")
+               HttpResponse(HttpStatusCode.OK, "true")
+            }
+
+            post("/foo") {
+               body("""{"test": false}""")
+               HttpResponse(HttpStatusCode.OK, "false")
+            }
+         }
+
+         val resp = client.post(server.url("/foo")) {
+            setBody("""{"test": true}""")
+         }
+         resp.status shouldBe HttpStatusCode.OK
+         resp.bodyAsText() shouldBe "true"
+
+         val resp2 = client.post(server.url("/foo")) {
+            setBody("""{"test": false}""")
+         }
+         resp2.status shouldBe HttpStatusCode.OK
+         resp2.bodyAsText() shouldBe "false"
+      }
+   }
+}


### PR DESCRIPTION
Sometimes we have a method that makes the same call to a client more than once, and passes in a different request body on each call. Right now, the stubs cannot tell that those are different, so the same response is returned. 

This PR is attempting to differentiate those calls so that if we have the following, we are able to use the different responses from each: 

```
server.mappings {
            post("/foo") {
               body("""{"test": true}""")
               HttpResponse(HttpStatusCode.OK, "true")
            }

            post("/foo") {
               body("""{"test": false}""")
               HttpResponse(HttpStatusCode.OK, "false")
            }
         }
```